### PR TITLE
Formalize Charter Edit Process

### DIFF
--- a/charter.md
+++ b/charter.md
@@ -86,7 +86,7 @@ The CAJA executive committee may meet informally at its discretion, but all majo
 
 ## EDITING THE CHARTER
 This charter is expected to change as CAJA grows. The process for making edits is as follows:
-1. Anyone makes changes to this document by editing it and committing the changes to a new branch. The branch should follow the naming convention `<author-name>/<change-description>`.
+1. Anyone makes changes to this document by editing it and committing the changes to a new branch[^1]. The branch should follow the naming convention `<author-name>/<change-description>`.
 2. When they are satisfied with the changes, they create a pull request on github and publicize this to (at least) the members of the voting council. The pull request must include, at a minimum:
      - A brief summary of the changes made
      - Why the changes are believed to be necessary
@@ -96,3 +96,6 @@ This charter is expected to change as CAJA grows. The process for making edits i
      - Merge the pull request (accept the changes)
      - Abstain
    Both actions - close or merge - require a 2/3 majority to pass. If this does not happen, the pull request remains open for comments and updates, and the vote is deferred until the next general meeting.
+
+
+[^1]: If editing via the github web interface, on your first commit, select the "Create a **new branch** for this commit and start a pull request" option instead of "Commit directly to the `main` branch". Enter your new branch's name in the text box. After you click "Propose Changes", it will take you to a page where you can make your pull request. If you're not ready to make a pull request, you can just go back to editing the charter - your changes will be kept. On subsequent changes, you can just keep the "Commit directly to the `your-branch-name` branch" option. 

--- a/charter.md
+++ b/charter.md
@@ -86,9 +86,10 @@ The CAJA executive committee may meet informally at its discretion, but all majo
 
 ## EDITING THE CHARTER
 This charter is expected to change as CAJA grows. The process for making edits is as follows:
-1. Anyone makes changes to this document by editing it and committing the changes to a new branch.
-2. When they are satisfied with the changes, they create a pull request on github and publicize this to (at least) the members of the voting council.
-     - The pull request should include, at a minimum, a) a brief summary of the changes made, and b) why the changes are believed to be necessary.
+1. Anyone makes changes to this document by editing it and committing the changes to a new branch. The branch should follow the naming convention `<author-name>/<change-description>`.
+2. When they are satisfied with the changes, they create a pull request on github and publicize this to (at least) the members of the voting council. The pull request must include, at a minimum:
+     - A brief summary of the changes made
+     - Why the changes are believed to be necessary
 3. Anyone may discuss the changes and provide feedback or suggestions in the comments of the pull request.
 4. At the next CAJA general meeting, the voting council votes to determine the status of the pull request. They must choose to
      - Close the pull request (reject the changes)

--- a/charter.md
+++ b/charter.md
@@ -83,3 +83,15 @@ The CAJA executive committee may meet informally at its discretion, but all majo
 1. **Prior:** Voting council or executive committee members submit topics for discussion to the Secretary. The Secretary posts a meeting agenda to the CAJA Discord server, ideally a few days before the scheduled meeting.  
 2. **Day of:** The Chairperson (or pre-appointed substitute) initiates the meeting and takes a quorum. Not all council or committee members are required to attend every meeting, but major decisions can only be made with council majority approval during a vote with sufficient voting members present. The Chairperson moderates the meeting per the agenda, prioritizing topics at their discretion. The Secretary takes minutes and notes on discussions and votes.  
 3. **After:** The Secretary submits minutes to the council in the CAJA Discord server, and optionally also to public channels for all California members. The Chairperson and Secretary schedule the next CAJA meeting with input from those expected to be present.
+
+## EDITING THE CHARTER
+This charter is expected to change as CAJA grows. The process for making edits is as follows:
+1. Anyone makes changes to this document by editing it and committing the changes to a new branch.
+2. When they are satisfied with the changes, they create a pull request on github and publicize this to (at least) the members of the voting council.
+     - The pull request should include, at a minimum, a) a brief summary of the changes made, and b) why the changes are believed to be necessary.
+3. Anyone may discuss the changes and provide feedback or suggestions in the comments of the pull request.
+4. At the next CAJA general meeting, the voting council votes to determine the status of the pull request. They must choose to
+     - Close the pull request (reject the changes)
+     - Merge the pull request (accept the changes)
+     - Abstain
+   Both actions - close or merge - require a 2/3 majority to pass. If this does not happen, the pull request remains open for comments and updates, and the vote is deferred until the next general meeting.

--- a/charter.md
+++ b/charter.md
@@ -98,4 +98,4 @@ This charter is expected to change as CAJA grows. The process for making edits i
    Both actions - close or merge - require a 2/3 majority to pass. If this does not happen, the pull request remains open for comments and updates, and the vote is deferred until the next general meeting.
 
 
-[^1]: If editing via the github web interface, on your first commit, select the "Create a **new branch** for this commit and start a pull request" option instead of "Commit directly to the `main` branch". Enter your new branch's name in the text box. After you click "Propose Changes", it will take you to a page where you can make your pull request. If you're not ready to make a pull request, you can just go back to editing the charter - your changes will be kept. On subsequent changes, you can just keep the "Commit directly to the `your-branch-name` branch" option. 
+[^1]: If editing via the github web interface, on your first commit, it will take you to a page to submit a pull request. You don't need to actually do that; you can just go back to editing the charter. Your newly created branch with all your changes will still be there.

--- a/charter.md
+++ b/charter.md
@@ -85,7 +85,8 @@ The CAJA executive committee may meet informally at its discretion, but all majo
 3. **After:** The Secretary submits minutes to the council in the CAJA Discord server, and optionally also to public channels for all California members. The Chairperson and Secretary schedule the next CAJA meeting with input from those expected to be present.
 
 ## EDITING THE CHARTER
-This charter is expected to change as CAJA grows. The process for making edits is as follows:
+This charter is expected to change as CAJA grows. The charter as available on the `main` branch (available at [github.com/california-jugger/charter](https://github.com/california-jugger/charter)) is always the current active charter.  
+The process for making edits is as follows:
 1. Anyone makes changes to this document by editing it and committing the changes to a new branch[^1]. The branch should follow the naming convention `<author-name>/<change-description>`.
 2. When they are satisfied with the changes, they create a pull request on github and publicize this to (at least) the members of the voting council. The pull request must include, at a minimum:
      - A brief summary of the changes made


### PR DESCRIPTION
## Edits

Added a section explaining the process to edit the charter on github. The basic process is:
- fork the repo and make edits there
- make a pull request
- voting council votes to merge

## Rationale

- editing the charter is a significant change, so a process for doing so that involves the voting council is needed.
- github is a platform that has already been designed to handle formal decisions about how to integrate proposed changes
- pull requests provide a space for discussion that is tied to the changes and is easy to refer to for the future, unlike discord where all discussion will get lost.
- pull requests force a very visible notification of any potential changes (and the `main` branch is protected, so nobody can just commit directly to `main` instead of opening a pull request)

## Feedback Requests
 - how much explanation of git/github is appropriate for the charter versus some external documentation?
 - Is a 2/3 majority a good number? Should it be a simple majority?